### PR TITLE
Fix typos in comments

### DIFF
--- a/arch/arm/mm/cache-l2x0.c
+++ b/arch/arm/mm/cache-l2x0.c
@@ -1379,9 +1379,9 @@ static void aurora_pa_range(unsigned long start, unsigned long end,
 	unsigned long range_end;
 	unsigned long flags;
 
-	/*
-	 * round start and end adresses up to cache line size
-	 */
+       /*
+        * round start and end addresses up to cache line size
+        */
 	start &= ~(CACHE_LINE_SIZE - 1);
 	end = ALIGN(end, CACHE_LINE_SIZE);
 

--- a/arch/powerpc/kernel/exceptions-64s.S
+++ b/arch/powerpc/kernel/exceptions-64s.S
@@ -2979,8 +2979,8 @@ TRAMP_REAL_BEGIN(rfscv_flush_fallback)
 	/* order ld/st prior to dcbt stop all streams with flushing */
 	sync
 
-	/*
-	 * The load adresses are at staggered offsets within cachelines,
+       /*
+        * The load addresses are at staggered offsets within cachelines,
 	 * which suits some pipelines better (on others it should not
 	 * hurt).
 	 */

--- a/drivers/input/serio/apbps2.c
+++ b/drivers/input/serio/apbps2.c
@@ -112,7 +112,7 @@ static int apbps2_open(struct serio *io)
 	while ((ioread32be(&priv->regs->status) & APBPS2_STATUS_DR) && --limit)
 		ioread32be(&priv->regs->data);
 
-	/* Enable reciever and it's interrupt */
+       /* Enable receiver and its interrupt */
 	iowrite32be(APBPS2_CTRL_RE | APBPS2_CTRL_RI, &priv->regs->ctrl);
 
 	return 0;

--- a/drivers/misc/vmw_vmci/vmci_context.h
+++ b/drivers/misc/vmw_vmci/vmci_context.h
@@ -98,7 +98,7 @@ struct vmci_ctx_chkpt_buf_info {
 };
 
 /*
- * VMCINotificationReceiveInfo: Used to recieve pending notifications
+ * VMCINotificationReceiveInfo: Used to receive pending notifications
  * for doorbells and queue pairs.
  */
 struct vmci_ctx_notify_recv_info {

--- a/drivers/mtd/devices/docg3.h
+++ b/drivers/mtd/devices/docg3.h
@@ -22,7 +22,7 @@
 #define DOC_IOSPACE_SIZE		0x2000
 
 /*
- * DOC G3 layout and adressing scheme
+ * DOC G3 layout and addressing scheme
  *   A page address for the block "b", plane "P" and page "p":
  *   address = [bbbb bPpp pppp]
  */

--- a/drivers/net/ethernet/ibm/ibmveth.c
+++ b/drivers/net/ethernet/ibm/ibmveth.c
@@ -408,8 +408,8 @@ static int ibmveth_remove_buffer_from_pool(struct ibmveth_adapter *adapter,
 	 * assume it is to be recycled.
 	 */
 	if (!reuse) {
-		/* remove the skb pointer to mark free. actual freeing is done
-		 * by upper level networking after gro_recieve
+               /* remove the skb pointer to mark free. actual freeing is done
+                * by upper level networking after gro_receive
 		 */
 		adapter->rx_buff_pool[pool].skbuff[index] = NULL;
 

--- a/drivers/net/wireless/realtek/rtlwifi/regd.c
+++ b/drivers/net/wireless/realtek/rtlwifi/regd.c
@@ -205,8 +205,8 @@ static void _rtl_reg_apply_active_scan_flags(struct wiphy *wiphy,
 		return;
 	}
 
-	/*
-	 *If a country IE has been recieved check its rule for this
+       /*
+        *If a country IE has been received check its rule for this
 	 *channel first before enabling active scan. The passive scan
 	 *would have been enforced by the initial processing of our
 	 *custom regulatory domain.

--- a/drivers/nfc/trf7970a.c
+++ b/drivers/nfc/trf7970a.c
@@ -61,7 +61,7 @@
  * support that.  So, if an abort is received before trf7970a_send_cmd()
  * has sent the command to the tag, it simply returns -ECANCELED.  If the
  * command has already been sent to the tag, then the driver continues
- * normally and recieves the response data (or error) but just before
+ * normally and receives the response data (or error) but just before
  * sending the data upstream, it frees the rx_skb and sends -ECANCELED
  * upstream instead.  If the command failed, that error will be sent
  * upstream.

--- a/drivers/scsi/lpfc/lpfc_bsg.c
+++ b/drivers/scsi/lpfc/lpfc_bsg.c
@@ -5001,10 +5001,10 @@ lpfc_bsg_issue_mbox(struct lpfc_hba *phba, struct bsg_job *job,
 							+ sizeof(MAILBOX_t));
 		}
 	} else if (phba->sli_rev == LPFC_SLI_REV4) {
-		/* Let type 4 (well known data) through because the data is
-		 * returned in varwords[4-8]
-		 * otherwise check the recieve length and fetch the buffer addr
-		 */
+               /* Let type 4 (well known data) through because the data is
+                * returned in varwords[4-8]
+                * otherwise check the receive length and fetch the buffer addr
+                */
 		if ((pmb->mbxCommand == MBX_DUMP_MEMORY) &&
 			(pmb->un.varDmp.type != DMP_WELL_KNOWN)) {
 			/* rebuild the command for sli4 using our own buffers

--- a/drivers/scsi/qla2xxx/qla_target.c
+++ b/drivers/scsi/qla2xxx/qla_target.c
@@ -1956,7 +1956,7 @@ static void qlt_24xx_retry_term_exchange(struct scsi_qla_host *vha,
 }
 
 /* drop cmds for the given lun
- * XXX only looks for cmds on the port through which lun reset was recieved
+ * XXX only looks for cmds on the port through which lun reset was received
  * XXX does not go through the list of other port (which may have cmds
  *     for the same lun)
  */

--- a/drivers/usb/gadget/udc/udc-xilinx.c
+++ b/drivers/usb/gadget/udc/udc-xilinx.c
@@ -128,7 +128,7 @@ struct xusb_req {
  * @name: name of the endpoint
  * @epnumber: endpoint number
  * @maxpacket: maximum packet size the endpoint can store
- * @buffer0count: the size of the packet recieved in the first buffer
+ * @buffer0count: the size of the packet received in the first buffer
  * @buffer1count: the size of the packet received in the second buffer
  * @curbufnum: current buffer of endpoint that will be processed next
  * @buffer0ready: the busy state of first buffer

--- a/sound/soc/tegra/tegra20_spdif.h
+++ b/sound/soc/tegra/tegra20_spdif.h
@@ -171,7 +171,7 @@
 
 /*
  * RX channel block data receive status:
- * 0=entire block not recieved yet.
+ * 0=entire block not received yet.
  * 1=received entire block of channel status,
  */
 #define TEGRA20_SPDIF_STATUS_IS_C				(1 << 21)

--- a/tools/testing/selftests/net/netfilter/conntrack_icmp_related.sh
+++ b/tools/testing/selftests/net/netfilter/conntrack_icmp_related.sh
@@ -171,7 +171,7 @@ table inet filter {
 }
 EOF
 
-# make sure NAT core rewrites adress of icmp error if nat is used according to
+# make sure NAT core rewrites address of icmp error if nat is used according to
 # conntrack nat information (icmp error will be directed at nsrouter1 address,
 # but it needs to be routed to nsclient1 address).
 ip netns exec "$nsrouter1" nft -f - <<EOF


### PR DESCRIPTION
## Summary
- clean up misspellings in various comments

## Testing
- `./scripts/checkpatch.pl -f drivers/input/serio/apbps2.c` *(fails: No module named 'ply')*

------
https://chatgpt.com/codex/tasks/task_b_68526b79eab48327adb06ed43fb28ea2