### PR TITLE
Fix regex usage in NI routing tool

### DIFF
--- a/drivers/comedi/drivers/ni_routing/tools/convert_csv_to_c.py
+++ b/drivers/comedi/drivers/ni_routing/tools/convert_csv_to_c.py
@@ -44,7 +44,7 @@ def routedict_to_structinit_single(name, D, return_name=False):
 
     lines.append('\t\t[B({})] = {{'.format(D0_sig))
     for D1_sig, value in D1:
-      if not re.match('[VIU]\([^)]*\)', value):
+      if not re.match(r'[VIU]\([^)]*\)', value):
         sys.stderr.write('Invalid register format: {}\n'.format(repr(value)))
         sys.stderr.write(
           'Register values should be formatted with V(),I(),or U()\n')


### PR DESCRIPTION
## Summary
- fix regex pattern to avoid invalid escape sequence warnings

## Testing
- `python3 -m py_compile drivers/comedi/drivers/ni_routing/tools/convert_csv_to_c.py`

------
https://chatgpt.com/codex/tasks/task_b_68526b663874832789184b0a0434652b